### PR TITLE
Issue 29: handle <ul>/<ol> with orphan text (no <li>)

### DIFF
--- a/news/29.bugfix
+++ b/news/29.bugfix
@@ -1,0 +1,1 @@
+Fixed `<ul>` and `<ol>` elements that contain orphan text without `<li>` children: the content is now wrapped into a synthetic `<li>` so it survives conversion instead of being silently dropped. @ericof

--- a/src/collective/html2blocks/blocks/slate/parser.py
+++ b/src/collective/html2blocks/blocks/slate/parser.py
@@ -387,13 +387,31 @@ def _handle_list_(element: t.Tag, tag_name: str) -> t.SlateItemGenerator:
     item = yield from item_generator(gen)
     if not item:
         return
-    children = []
+    children: list[t.SlateBlockItem] = []
     allowed_children = ["li", tag_name]
-    # Remove not valid child
+    orphan_buffer: list[t.SlateBlockItem] = []
+
+    def _flush_orphan() -> None:
+        if orphan_buffer:
+            children.append({"type": "li", "children": list(orphan_buffer)})
+            orphan_buffer.clear()
+
     for child in item.get("children", []):
-        if not (isinstance(child, dict) and child.get("type", "") in allowed_children):
+        if isinstance(child, dict) and child.get("type", "") in allowed_children:
+            _flush_orphan()
+            children.append(child)
             continue
-        children.append(child)
+        # Orphan inline content inside <ul>/<ol>: wrap meaningful runs into a
+        # synthetic <li> so malformed-but-real-world markup survives. Pure
+        # whitespace text nodes (typical between sibling <li>s) are discarded.
+        if isinstance(child, dict) and slate.is_simple_text(child):
+            if child.get("text", "").strip():
+                orphan_buffer.append(child)
+            continue
+        if isinstance(child, dict):
+            orphan_buffer.append(child)
+    _flush_orphan()
+
     if not children:
         return None
     item["children"] = children

--- a/tests/_data/test_slate_block.yml
+++ b/tests/_data/test_slate_block.yml
@@ -657,6 +657,76 @@ params:
       - path: "0/value/0/children/7/type"
         expected: 'li'
 
+  - name: Issue 29 - Unordered list with orphan text (no li)
+    src: '<ul type="disc">IBGE https://cidades.ibge.gov.br/brasil/mg/uberlandia/panorama</ul>'
+    tests:
+      - path: "0/@type"
+        expected: 'slate'
+      - path: "0/plaintext"
+        expected: 'IBGE https://cidades.ibge.gov.br/brasil/mg/uberlandia/panorama'
+      - path: "0/value/0/type"
+        expected: 'ul'
+      - path: "len:0/value/0/children"
+        expected: 1
+      - path: "0/value/0/children/0/type"
+        expected: 'li'
+      - path: "0/value/0/children/0/children/0/text"
+        expected: 'IBGE https://cidades.ibge.gov.br/brasil/mg/uberlandia/panorama'
+
+  - name: Issue 29 - Ordered list with orphan text (no li)
+    src: '<ol>Only text, no list items</ol>'
+    tests:
+      - path: "0/@type"
+        expected: 'slate'
+      - path: "0/plaintext"
+        expected: 'Only text, no list items'
+      - path: "0/value/0/type"
+        expected: 'ol'
+      - path: "len:0/value/0/children"
+        expected: 1
+      - path: "0/value/0/children/0/type"
+        expected: 'li'
+      - path: "0/value/0/children/0/children/0/text"
+        expected: 'Only text, no list items'
+
+  - name: Issue 29 - Unordered list mixing orphan text and a real li
+    src: '<ul>orphan text<li>real item</li></ul>'
+    tests:
+      - path: "0/@type"
+        expected: 'slate'
+      - path: "0/plaintext"
+        expected: 'orphan text real item'
+      - path: "0/value/0/type"
+        expected: 'ul'
+      - path: "len:0/value/0/children"
+        expected: 2
+      - path: "0/value/0/children/0/type"
+        expected: 'li'
+      - path: "0/value/0/children/0/children/0/text"
+        expected: 'orphan text'
+      - path: "0/value/0/children/1/type"
+        expected: 'li'
+      - path: "0/value/0/children/1/children/0/text"
+        expected: 'real item'
+
+  - name: Issue 29 - Unordered list with orphan text and inline link
+    src: '<ul>text <a href="http://example.com">link</a></ul>'
+    tests:
+      - path: "0/@type"
+        expected: 'slate'
+      - path: "0/value/0/type"
+        expected: 'ul'
+      - path: "len:0/value/0/children"
+        expected: 1
+      - path: "0/value/0/children/0/type"
+        expected: 'li'
+      - path: "0/value/0/children/0/children/0/text"
+        expected: 'text '
+      - path: "0/value/0/children/0/children/1/type"
+        expected: 'link'
+      - path: "0/value/0/children/0/children/1/children/0/text"
+        expected: 'link'
+
   - name: Processing a sub
     src: <sub>Hello world!</sub>
     tests:


### PR DESCRIPTION
## Summary

Handles `<ul>` / `<ol>` elements that contain orphan inline content (text, `<a>`, `<span>`, …) without `<li>` wrappers. Previously such content was silently dropped — the entire list returned `None` when no `<li>` survived, and orphan content alongside real `<li>` siblings disappeared from the value tree.

Now, meaningful orphan inline runs are grouped into a synthetic `<li>` so malformed-but-real-world markup keeps its content. Whitespace-only orphan text (the typical newline between sibling `<li>`s) is still discarded — existing well-formed lists are unchanged.

Example from the wild that motivated this:

```html
<ul type="disc">IBGE https://cidades.ibge.gov.br/brasil/mg/uberlandia/panorama</ul>
```

## Implementation

[src/collective/html2blocks/blocks/slate/parser.py](src/collective/html2blocks/blocks/slate/parser.py) — `_handle_list_` now walks `<ul>`/`<ol>` children, buffers orphan inline items, and flushes them into a synthetic `<li>` before each real `<li>` and at the end.

## Test plan

- [x] New YAML cases in [tests/_data/test_slate_block.yml](tests/_data/test_slate_block.yml) covering orphan text in `<ul>`, orphan text in `<ol>`, mixed orphan + real `<li>`, orphan text + inline `<a>`
- [x] Red-to-green confirmed (23 failures → 27 passes for the new cases)
- [x] Full suite green — 877 tests pass
- [x] `make format` / `make lint` (ruff + mypy 10/10) clean
- [x] News fragment added (`news/29.bugfix`)

Closes #29