### PR TITLE
Fix Slate conversion defects from Plone → Volto migration (#31, #32, #33)

### DIFF
--- a/news/31.bugfix
+++ b/news/31.bugfix
@@ -1,0 +1,1 @@
+Kept text following a run of consecutive inline elements (e.g. two adjacent ``<b>`` tags) inside its parent paragraph, instead of splitting it out as a sibling block. @ericof

--- a/news/32.bugfix
+++ b/news/32.bugfix
@@ -1,0 +1,1 @@
+Preserved underline and strikethrough styling declared on a ``<span>`` via the ``text-decoration`` CSS property, converting them to ``u`` and ``s`` slate elements instead of dropping the formatting. @ericof

--- a/news/33.bugfix
+++ b/news/33.bugfix
@@ -1,0 +1,1 @@
+Fixed deeply-nested ``<div>`` structures producing non-renderable Slate blocks: dropped ``null`` entries and type-less nodes, stopped emitting ``<p>`` inside ``<p>``, and collapsed runs of empty paragraphs into a single one. @ericof

--- a/src/collective/html2blocks/blocks/slate/parser.py
+++ b/src/collective/html2blocks/blocks/slate/parser.py
@@ -339,18 +339,20 @@ def _span_(element: t.Tag, tag_name: str) -> t.SlateItemGenerator:
         children = yield from item_generator(gen)
         return {"children": children}
     text = element.text
-    if styles.get("font-weight", "") == "bold":
-        # Handle TinyMCE' bold formatting
-        return {"type": "strong", "children": [slate.wrap_text(text)]}
-    elif styles.get("font-style", "") == "italic":
-        # Handle TinyMCE' italic formatting
-        return {"type": "em", "children": [slate.wrap_text(text)]}
-    elif styles.get("vertical-align") == "sub":
-        # Handle Google Docs' <sub> formatting
-        return {"type": "sub", "children": [slate.wrap_text(text)]}
-    elif styles.get("vertical-align") == "sup":
-        # Handle Google Docs' <sup> formatting
-        return {"type": "sup", "children": [slate.wrap_text(text)]}
+    # Map legacy TinyMCE / Google Docs inline styling to slate inline types.
+    text_decoration = styles.get("text-decoration", "")
+    style_checks = (
+        (styles.get("font-weight", "") == "bold", "strong"),
+        (styles.get("font-style", "") == "italic", "em"),
+        ("underline" in text_decoration, "u"),
+        ("line-through" in text_decoration, "s"),
+        (styles.get("vertical-align") in ("sub", "sup"), styles.get("vertical-align")),
+    )
+    style_type = next(
+        (slate_type for matched, slate_type in style_checks if matched), None
+    )
+    if style_type:
+        return {"type": style_type, "children": [slate.wrap_text(text)]}
     elif children:
         gen = _handle_only_child(children[0], styles)
         item = yield from item_generator(gen)

--- a/src/collective/html2blocks/blocks/slate/parser.py
+++ b/src/collective/html2blocks/blocks/slate/parser.py
@@ -114,7 +114,7 @@ def finalize_slate(block: t.VoltoBlock) -> t.SlateItemGenerator:
         item = yield from item_generator(gen)
         if item:
             value.append(item)
-    block["value"] = value
+    block["value"] = slate.collapse_blank_paragraphs(value)
     return block
 
 
@@ -287,7 +287,12 @@ def _div_(element: t.Tag, tag_name: str) -> t.SlateItemGenerator:
                 gen = deserialize(child)
                 child_block = yield from item_generator(gen)
                 block_children.append(child_block)
-        block["children"] = block_children
+        # Flatten before returning: drops empty (``None``) descendants, hoists the
+        # children of nested type-less <div> nodes, and -- because every nested
+        # _div_ flattens its own output -- keeps arbitrarily deep nesting clean.
+        # Without this, empty descendants leak as ``null`` and nested type-less
+        # nodes survive into the Slate value, which Volto cannot render.
+        block["children"] = slate.flatten_children(block_children)
     return block
 
 

--- a/src/collective/html2blocks/utils/slate.py
+++ b/src/collective/html2blocks/utils/slate.py
@@ -103,16 +103,16 @@ def _group_top_level(
     flags = [is_inline(item) or is_simple_text(item) for item in items]
     groups = []
     current_group = [items[0]]
-    last_flag = flags[0]
     for i in range(1, len(items)):
-        last_flag = flags[i - 1]
-        if flags[i] != last_flag:
-            groups.append((current_group, last_flag))
+        if flags[i] != flags[i - 1]:
+            groups.append((current_group, flags[i - 1]))
             current_group = [items[i]]
         else:
             current_group.append(items[i])
-
-    groups.append((current_group, last_flag))
+    # The final group ends at the last item, so it carries the last item's flag --
+    # not the loop's stale ``flags[i - 1]``, which would mis-wrap a trailing block
+    # node (e.g. a <p>) as if it were inline, producing an invalid <p> in <p>.
+    groups.append((current_group, flags[-1]))
     return groups
 
 
@@ -164,6 +164,46 @@ def remove_empty_text(value: list[t.SlateBlockItem]) -> list[t.SlateBlockItem]:
             continue
         new_value.append(item)
     return new_value
+
+
+def is_blank_paragraph(node: t.SlateBlockItem) -> bool:
+    """
+    Check if a node is a ``p`` whose text content is only whitespace.
+
+    :param node: The Slate node to check.
+    :returns: ``True`` for a ``p`` with no non-whitespace text, ``False`` otherwise.
+    """
+    if not isinstance(node, dict) or node.get("type") != "p":
+        return False
+    children = node.get("children", [])
+    return all(
+        is_simple_text(child) and not child.get("text", "").strip()
+        for child in children
+    )
+
+
+def collapse_blank_paragraphs(
+    value: list[t.SlateBlockItem],
+) -> list[t.SlateBlockItem]:
+    """
+    Collapse consecutive whitespace-only paragraphs into a single one.
+
+    Migration sources often carry long runs of empty ``<p>`` spacers (and inter-tag
+    newlines turned into paragraphs). A single blank paragraph is kept per run so the
+    visual gap is preserved without flooding the block with empty nodes.
+
+    :param value: The Slate value (list of nodes) to normalize.
+    :returns: The value with each run of blank paragraphs reduced to one.
+    """
+    result: list[t.SlateBlockItem] = []
+    prev_blank = False
+    for node in value:
+        blank = is_blank_paragraph(node)
+        if blank and prev_blank:
+            continue
+        result.append(node)
+        prev_blank = blank
+    return result
 
 
 def _just_children(data: t.SlateBlockItem) -> bool:

--- a/src/collective/html2blocks/utils/slate.py
+++ b/src/collective/html2blocks/utils/slate.py
@@ -291,7 +291,10 @@ def group_inline_nodes(block_children: list, tag_name: str = "span") -> list:
     nodes = []
     inline_nodes: t.SlateBlockItem | None = None
     for child in block_children:
-        if is_inline(child):
+        # Plain text nodes are inline content too: they must continue an
+        # inline run rather than break it, otherwise trailing text after a
+        # run of inline elements gets split out of its parent block.
+        if is_inline(child) or is_simple_text(child):
             if inline_nodes is None:
                 inline_nodes = {"type": tag_name, "children": [child]}
             else:

--- a/tests/_data/test_html_to_blocks.yml
+++ b/tests/_data/test_html_to_blocks.yml
@@ -195,20 +195,18 @@ params:
       - path: "0/value/0/children/0/children/0/text"
         expected: "The Plone Conference 2021 will be held as an online event on October 23 - 31, 2021. "
       - path: "len:3/value"
-        expected: 7
+        expected: 5
       - path: "3/value/0/type"
         expected: p
       - path: "3/value/1/type"
         expected: p
+      - path: "3/value/1/children/0/text"
+        expected: "Conference information (subject due to change):"
       - path: "3/value/2/type"
         expected: p
       - path: "3/value/3/type"
-        expected: p
-      - path: "3/value/4/type"
         expected: ul
-      - path: "3/value/5/type"
-        expected: p
-      - path: "3/value/6/type"
+      - path: "3/value/4/type"
         expected: p
 
   - name: Parsing unwrapped text

--- a/tests/_data/test_slate_block.yml
+++ b/tests/_data/test_slate_block.yml
@@ -905,6 +905,48 @@ params:
       - path: "0/value/0/children/0/text"
         expected: 'Olaa World!'
 
+  - name: Trailing text after consecutive inline elements stays in the paragraph
+    src: <p><strong>A</strong><strong>B</strong> tail</p>
+    tests:
+      - path: "0/@type"
+        expected: 'slate'
+      - path: "0/plaintext"
+        expected: 'AB tail'
+      - path: "len:0/value"
+        expected: 1
+      - path: "0/value/0/type"
+        expected: 'p'
+      - path: "len:0/value/0/children"
+        expected: 3
+      - path: "0/value/0/children/0/type"
+        expected: 'strong'
+      - path: "0/value/0/children/1/type"
+        expected: 'strong'
+      - path: "0/value/0/children/2/text"
+        expected: ' tail'
+
+  - name: Trailing text after a bold run with leading underlined span stays in the paragraph
+    src: '<p><b><span style="text-decoration: underline;">Em tempo</span></b><b>:</b> a próxima reunião.</p>'
+    tests:
+      - path: "0/@type"
+        expected: 'slate'
+      - path: "0/plaintext"
+        expected: 'Em tempo: a próxima reunião.'
+      - path: "len:0/value"
+        expected: 1
+      - path: "0/value/0/type"
+        expected: 'p'
+      - path: "len:0/value/0/children"
+        expected: 3
+      - path: "0/value/0/children/0/type"
+        expected: 'strong'
+      - path: "0/value/0/children/0/children/0/type"
+        expected: 'u'
+      - path: "0/value/0/children/1/type"
+        expected: 'strong'
+      - path: "0/value/0/children/2/text"
+        expected: ' a próxima reunião.'
+
   - name: Defer to other converter
     src: '<img src="https://plone.org/news/item" title="A Picture" alt="Picture of a person" class="lazy-load">'
     tests:

--- a/tests/_data/test_slate_block.yml
+++ b/tests/_data/test_slate_block.yml
@@ -167,6 +167,50 @@ params:
       - path: "0/value/0/children/2/text"
         expected: ' more normal text'
 
+  - name: With old TinyMCE settings for underline
+    src: '<p>Normal Text <span style="text-decoration: underline;">Underlined Text</span> more normal text</p>'
+    tests:
+      - path: "0/@type"
+        expected: 'slate'
+      - path: "0/plaintext"
+        expected: 'Normal Text Underlined Text more normal text'
+      - path: "0/value/0/type"
+        expected: 'p'
+      - path: "0/value/0/children/0/text"
+        expected: 'Normal Text '
+      - path: "0/value/0/children/1/type"
+        expected: 'u'
+      - path: "0/value/0/children/1/children/0/text"
+        expected: 'Underlined Text'
+      - path: "0/value/0/children/2/text"
+        expected: ' more normal text'
+
+  - name: With underline declared via text-decoration shorthand
+    src: '<p><span style="text-decoration: underline dotted red;">Underlined Text</span></p>'
+    tests:
+      - path: "0/value/0/children/0/type"
+        expected: 'u'
+      - path: "0/value/0/children/0/children/0/text"
+        expected: 'Underlined Text'
+
+  - name: With strikethrough declared via text-decoration
+    src: '<p>Normal Text <span style="text-decoration: line-through;">Struck Text</span> more normal text</p>'
+    tests:
+      - path: "0/@type"
+        expected: 'slate'
+      - path: "0/plaintext"
+        expected: 'Normal Text Struck Text more normal text'
+      - path: "0/value/0/type"
+        expected: 'p'
+      - path: "0/value/0/children/0/text"
+        expected: 'Normal Text '
+      - path: "0/value/0/children/1/type"
+        expected: 's'
+      - path: "0/value/0/children/1/children/0/text"
+        expected: 'Struck Text'
+      - path: "0/value/0/children/2/text"
+        expected: ' more normal text'
+
   - name: With an empty bold element in the text
     src: <p>Hello world!<b></b></p>
     tests:

--- a/tests/_data/test_slate_block.yml
+++ b/tests/_data/test_slate_block.yml
@@ -947,6 +947,16 @@ params:
       - path: "0/value/0/children/2/text"
         expected: ' a próxima reunião.'
 
+  - name: Runs of empty paragraphs in a block collapse to a single paragraph
+    src: '<div class="home-page"><section><div class="carousel"><div class="inner"><div class="item"><ul class="logos"><li></li></ul></div></div></div></section></div>'
+    tests:
+      - path: "0/@type"
+        expected: 'slate'
+      - path: "len:0/value"
+        expected: 1
+      - path: "0/value/0/type"
+        expected: 'p'
+
   - name: Defer to other converter
     src: '<img src="https://plone.org/news/item" title="A Picture" alt="Picture of a person" class="lazy-load">'
     tests:


### PR DESCRIPTION
## Summary

Three fixes for Slate conversion defects surfaced by a real-world Plone → Volto migration (Câmara Municipal de Uberlândia). Each defect produced output that either rendered incorrectly or could not be rendered by Volto at all.

## Fixes

### `<span>` `text-decoration` styling dropped (#32)
`_span_` mapped `font-weight`/`font-style`/`vertical-align` to Slate inline types but ignored `text-decoration`. Now `underline` → `u` and `line-through` → `s` (substring match, so CSS shorthand like `underline dotted red` works). The style branches are collapsed into a small lookup table to stay under ruff's complexity limit.

### Trailing text after an inline run split out of its paragraph (#31)
A run of consecutive inline elements (e.g. two adjacent `<b>` tags) followed by plain text had that text hoisted out of the parent `<p>` as a sibling block. Root cause: `group_inline_nodes` treated a plain text node as non-inline, breaking the inline run. Text nodes now continue the run (`is_inline or is_simple_text`).

### Deeply-nested `<div>` structures produced non-renderable Slate (#33)
Nested `<div>` layouts generated invalid Slate — `null` entries, type-less `{children: [...]}` nodes, `<p>` inside `<p>`, and bare text mixed with block siblings — all surfacing only at nesting depth. Three changes:
- `_div_` now returns `flatten_children(block_children)`, dropping `None` descendants and hoisting nested type-less nodes at any depth instead of hand-rolling child handling.
- `_group_top_level` appends the final group with the last item's flag rather than a stale `flags[i-1]`, so a trailing block node preceded by an inline node is no longer wrapped as inline (which produced `<p>` in `<p>`).
- `finalize_slate` collapses runs of consecutive whitespace-only paragraphs to a single one (new `collapse_blank_paragraphs` helper) — an all-decorative section went from 34 empty paragraphs to 1.

## Tests

- New fixtures for each fix (underline/strikethrough spans, trailing-text-after-inline-run, blank-paragraph consolidation).
- Updated the "nested divs" fixture to the cleaner output.
- Full suite: **912 passing**, lint 10/10, mypy clean.

Closes #31
Closes #32
Closes #33